### PR TITLE
internal/crashmonitor: add the options parameter to the setCrashOutput

### DIFF
--- a/internal/crashmonitor/monitor.go
+++ b/internal/crashmonitor/monitor.go
@@ -26,7 +26,7 @@ import (
 // TODO(adonovan): eliminate once go1.23+ is assured.
 func Supported() bool { return setCrashOutput != nil }
 
-var setCrashOutput func(*os.File) error // = runtime.SetCrashOutput on go1.23+
+var setCrashOutput func(*os.File, debug.CrashOptions) error // = runtime.SetCrashOutput on go1.23+
 
 // Parent sets up the parent side of the crashmonitor. It requires
 // exclusive use of a writable pipe connected to the child process's stdin.
@@ -34,7 +34,7 @@ func Parent(pipe *os.File) {
 	writeSentinel(pipe)
 	// Ensure that we get pc=0x%x values in the traceback.
 	debug.SetTraceback("system")
-	setCrashOutput(pipe)
+	setCrashOutput(pipe, debug.CrashOptions{})
 }
 
 // Child runs the part of the crashmonitor that runs in the child process.


### PR DESCRIPTION
This PR adds the options parameter to the setCrashOutput function.

Updates golang/go#67182