### PR TITLE
internal/telemetry: disable telemetry on z/OS

### DIFF
--- a/internal/telemetry/dir.go
+++ b/internal/telemetry/dir.go
@@ -160,4 +160,5 @@ const DisabledOnPlatform = false ||
 	runtime.GOOS == "js" || // #60971
 	runtime.GOOS == "wasip1" || // #60971
 	runtime.GOOS == "plan9" || // https://github.com/golang/go/issues/57540#issuecomment-1470766639
-	runtime.GOARCH == "mips" || runtime.GOARCH == "mipsle" // mips lacks cross-process 64-bit atomics
+	runtime.GOARCH == "mips" || runtime.GOARCH == "mipsle" || // mips lacks cross-process 64-bit atomics
+        runtime.GOOS == "zos" // zos is an unofficial port


### PR DESCRIPTION
disables telemetry on z/OS

z/OS is not going to be supported because:
 - It is an unofficial team that maintains this port
 - Supporting this feature on z/OS has proven to be difficult (platform issues)
 - The z/OS team does not plan on supporting this feature at this time